### PR TITLE
Update action-gh-release to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           java-version: 17
           pmd: false
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: target/maintenance-mode-*.hpi


### PR DESCRIPTION
Fixes the NodeJS 16 deprecation issue (#151).