### PR TITLE
Use CodeQL scan without build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           languages: java
           queries: +security-and-quality
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+          build-mode: none
       - name: CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
CodeQL supports analysing without build for Java now.