### PR TITLE
Remove method override

### DIFF
--- a/src/main/java/bv/offa/jenkins/maintenance/MaintenanceModeLink.java
+++ b/src/main/java/bv/offa/jenkins/maintenance/MaintenanceModeLink.java
@@ -93,13 +93,6 @@ public class MaintenanceModeLink extends ManagementLink implements Saveable
         return Category.TOOLS;
     }
 
-    @NonNull
-    @Override
-    public Permission getRequiredPermission()
-    {
-        return Jenkins.ADMINISTER;
-    }
-
     public boolean isActive()
     {
         return active;


### PR DESCRIPTION
The permission is already set correctly in the super method and checked by a test case.